### PR TITLE
Optimizing the format of Curl command on first prompt

### DIFF
--- a/quickstarts/rest/Prompting_REST.ipynb
+++ b/quickstarts/rest/Prompting_REST.ipynb
@@ -142,8 +142,9 @@
         "    -X POST \\\n",
         "    -d '{\n",
         "      \"contents\": [{\n",
-        "        \"parts\":[{\n",
-        "          \"text\": \"Give me python code to sort a list.\"}]}]}' 2> /dev/null"
+        "        \"parts\":[{\"text\": \"Give me python code to sort a list.\"}]\n",
+        "        }]",
+        "       }' 2> /dev/null"
       ]
     },
     {

--- a/quickstarts/rest/Prompting_REST.ipynb
+++ b/quickstarts/rest/Prompting_REST.ipynb
@@ -143,7 +143,7 @@
         "    -d '{\n",
         "      \"contents\": [{\n",
         "        \"parts\":[{\"text\": \"Give me python code to sort a list.\"}]\n",
-        "        }]",
+        "        }]\n",
         "       }' 2> /dev/null"
       ]
     },


### PR DESCRIPTION
Optimizing the format of Curl command on first prompt

The current formatting of curl command is confusing. Making reader think it's missing enclosing